### PR TITLE
add param.Config

### DIFF
--- a/envconfig/param.py
+++ b/envconfig/param.py
@@ -10,6 +10,7 @@ class Types(pyEnum):
     Bool = "Bool"
     Enum = "Enum"
     Float = "Float"
+    Config = "Config"
 
 
 def _boolean(value):
@@ -90,3 +91,16 @@ class Enum(Param):
 class Float(Param):
     def _cast(self, value):
         return float(value)
+
+
+class Config(Param):
+    def __init__(self, cls, default=None):
+        self.cls = cls
+        self.default = default
+
+    def __call__(self, _name):
+        try:
+            value = self.cls()
+            return value
+        except KeyError:
+            return self.default

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -21,6 +21,9 @@ def mock_env(monkeypatch):
     monkeypatch.setenv("COLOUR_BLUE", "blue")
     monkeypatch.setenv("COLOUR_YELLOW", "yellow")
     monkeypatch.setenv("FLOAT_CONFIG", "3.141")
+    monkeypatch.setenv("C1_STR", "C1")
+    monkeypatch.setenv("C2_STR", "C2")
+    monkeypatch.setenv("C3_STR", "C3")
 
 
 @pytest.mark.parametrize(
@@ -156,3 +159,39 @@ def test_float_parse(mock_env):
     value = f("FLOAT_CONFIG")
     assert value == 3.141
     assert type(value) is float
+
+
+def test_config_public_type():
+    c = param.Config(None)
+    assert c.type == "Config"
+
+
+def test_config_parse():
+    class C1(EnvConfig):
+        C1_STR = param.Str()
+
+    class C2(EnvConfig):
+        C2_STR = param.Str()
+        C1 = param.Config(C1)
+
+    c2 = C2()
+    assert c2.C2_STR == "C2"
+    assert c2.C1.C1_STR == "C1"
+
+
+def test_config_parse_nested():
+    class C1(EnvConfig):
+        C1_STR = param.Str()
+
+    class C2(EnvConfig):
+        C2_STR = param.Str()
+        C1 = param.Config(C1)
+
+    class C3(EnvConfig):
+        C3_STR = param.Str()
+        C2 = param.Config(C2)
+
+    c3 = C3()
+    assert c3.C3_STR == "C3"
+    assert c3.C2.C2_STR == "C2"
+    assert c3.C2.C1.C1_STR == "C1"


### PR DESCRIPTION
# Motivation

IMO if a module has a `EnvConfig` defined inside it, that serves as a pretty good piece of documentation for what the module needs in order to run. However, if your main module is calling out to other modules which themselves have their own `EnvConfigs`, this information would not be captured in the main module's `EnvConfig`, and it doesn't do as good a job of being documentation anymore.

If your main module is calling out to 1 other module, this is fine because you can just create both, e.g.:

```python
# in main module
import other_module

class Config(EnvConfig):
    # .... config for this module goes here

if __name__ == "__main__":
    config = Config()

    # ... do stuff with config
    main(config)

    # ... decide we want to call out to other_module
    other_module_config = other_module.Config()
    other_module.main(other_module_config)
```

But if you have more than 1 "level" of this, things start getting really cluttered.

Also, if you forgot to set a value for a `required=True` param in `other_module.Config()`, you won't get an exception until after `main(config)` finishes. If `main(config)` is quite slow to run this could waste you quite a lot of time before realising that you forgot 😞.

# Change

This PR adds `param.Config`, which allows you to define `EnvConfig`s that are composed of other `EnvConfig`s.

The earlier example would now look like this:

```python
# in main module
import other_module

class Config(EnvConfig):
    # .... config for this module goes here

    other_module = param.Config(other_module.Config)

if __name__ == "__main__":
    config = Config()

    # ... do stuff with config
    main(config)

    # ... decide we want to call out to other_module
    other_module.main(config.other_module_config)
```

This addresses the earlier issues mentioned:

- `other_module.Config` is now documented as being part of what's needed for the main module to run
- if `other_module` itself calls out to `third_module`, we can declare a `param.Config(third_module.Config)` on `other_module.Config` and don't need to do it in the main module
- the main module will immediately abort and "fail fast" if any `required=True` params from `other_module.Config` are missing
- small ergonomic improvement; only 1 line `config = Config()` to check all of these

A more specific use case that inspired this for me: writing scripts that run other scripts on a remote host; specifically a script that runs another script on AWS Batch.

Here's a rough outline of the way it works; pseudo-coded for brevity:

```python
import remote_script # import remote_script.py, the script i will be running on AWS Batch

class Config(EnvConfig):
    JOB_QUEUE = param.Str(required=True) # the name of the queue to put the job on
    JOB_NAME = param.Str(required=True) # name for the job)

    # I will be running the remote_script.py on AWS Batch.
    # I declare a dependency on remote_script.Config so that I can pass these on to AWS Batch
    remote_script_config = param.Config(remote_script.Config)

if __name__ == "__main__":
    # 1 line, automatically checks that we have set all the necessary envvars without
    # waiting for job to start only to immediately fail due to missing envvars...
    config = Config()

    # populate envvars formatted for AWS Batch API (pseudo)
    envvars = []
    for key, value in config.remote_script_config.params.items():
        envvars.append({'name': key, 'value': str(value)})

    # submit job to AWS Batch (pseudo)
    submit_job_to_aws_batch(config.JOB_QUEUE, config.JOB_NAME, script='remote_script.py', envvars=envvars)
```

Keen to hear your thoughts.