### PR TITLE
add datetime and timedelta

### DIFF
--- a/envconfig/param.py
+++ b/envconfig/param.py
@@ -133,16 +133,21 @@ class Datetime(Param):
 
 
 class Timedelta(Param):
-    def __init__(self, units, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def __call__(self, name):
+        self.units = name.split('_')[-1].lower()
         value = super().__call__(name)
-        try:
-            converted = int(value)
-        except:
-            converted = float(value)
+        return value
 
-        units = name.split('_')[-1].lower()
-        td = timedelta(**{units: converted})
-        return td
+    def _cast(self, value):
+        if isinstance(value, timedelta):
+            return value
+        else:
+            try:
+                converted = int(value)
+            except:
+                converted = float(value)
+            td = timedelta(**{self.units: converted})
+            return td

--- a/envconfig/param.py
+++ b/envconfig/param.py
@@ -1,5 +1,6 @@
 import os
 from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
 
 from enum import Enum as pyEnum
 
@@ -10,6 +11,8 @@ class Types(pyEnum):
     Bool = "Bool"
     Enum = "Enum"
     Float = "Float"
+    Datetime = "Datetime"
+    Timedelta = "Timedelta"
 
 
 def _boolean(value):
@@ -90,3 +93,56 @@ class Enum(Param):
 class Float(Param):
     def _cast(self, value):
         return float(value)
+
+
+class Datetime(Param):
+    def __init__(self, format_suffix: str = "_FORMAT", format_override: str = None, format_default: str = "%Y-%m-%dT%H:%M:%S%z", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.format_suffix = format_suffix
+        self.format_override = format_override
+        self.format_default = format_default
+
+    def __call__(self, name):
+        # Some environment variables will be prefixed
+        # this will return env var with prefix + name
+        if not self.override:
+            name = self.prefix + name if self.prefix else name
+        else:
+            name = self.override
+
+        if not self.format_override:
+            format_name = name + self.format_suffix
+        else:
+            format_name = self.format_override
+
+        value_format = os.getenv(format_name, self.format_default)
+
+        if name in os.environ:
+            value_str = os.environ[name]
+            value = datetime.strptime(value_str, value_format)
+
+        elif self.required:
+            raise KeyError(f"Could not find '{name}' in environment.")
+
+        elif isinstance(self.default, str):
+            value = datetime.strptime(self.default, value_format)
+        else:
+            value = self.default
+
+        return value
+
+
+class Timedelta(Param):
+    def __init__(self, units, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, name):
+        value = super().__call__(name)
+        try:
+            converted = int(value)
+        except:
+            converted = float(value)
+
+        units = name.split('_')[-1].lower()
+        td = timedelta(**{units: converted})
+        return td

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from enum import Enum
 
 import pytest
@@ -21,6 +23,10 @@ def mock_env(monkeypatch):
     monkeypatch.setenv("COLOUR_BLUE", "blue")
     monkeypatch.setenv("COLOUR_YELLOW", "yellow")
     monkeypatch.setenv("FLOAT_CONFIG", "3.141")
+    monkeypatch.setenv("DATETIME", "2022-06-16T18:35:13+12:00")
+    monkeypatch.setenv("DATETIME_2", "2022-06-16 18:35:13")
+    monkeypatch.setenv("DATETIME_2_FORMAT", "%Y-%m-%d %H:%M:%S")
+    monkeypatch.setenv("TIMEDELTA_DAYS", "1")
 
 
 @pytest.mark.parametrize(
@@ -156,3 +162,27 @@ def test_float_parse(mock_env):
     value = f("FLOAT_CONFIG")
     assert value == 3.141
     assert type(value) is float
+
+
+def test_datetime_public_type():
+    d = param.Datetime()
+    assert d.type == "Datetime"
+
+
+def test_datetime_parse():
+    d = param.Datetime()
+    value = d("DATETIME")
+    assert value == datetime(2022, 6, 16, 18, 35, 13, tzinfo=timezone(12))
+
+
+def test_datetime_parse_2():
+    d = param.Datetime()
+    value = d("DATETIME_2")
+    assert value == datetime(2022, 6, 16, 18, 35, 13, tzinfo=timezone(12))
+
+
+def test_timedelta():
+    t = param.Timedelta()
+    value = t("TIMEDELTA")
+    assert value == timedelta(days=1)
+    assert value.total_seconds() == 86400

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -183,6 +183,33 @@ def test_datetime_parse_2():
 
 def test_timedelta():
     t = param.Timedelta()
-    value = t("TIMEDELTA")
-    assert value == timedelta(days=1)
+    value = t("TIMEDELTA_DAYS")
     assert value.total_seconds() == 86400
+
+
+def test_timedelta_default_int():
+    t = param.Timedelta(default=7)
+    value = t("TIMEDELTA_NOT_DEFINED_HOURS")
+    assert isinstance(value, timedelta)
+    assert value.total_seconds() = 7 * 24 * 3600
+
+
+def test_timedelta_default_float():
+    t = param.Timedelta(default=7.0)
+    value = t("TIMEDELTA_NOT_DEFINED_MINUTES")
+    assert isinstance(value, timedelta)
+    assert value.total_seconds() == 7.0 * 60
+
+
+def test_timedelta_default_timedelta():
+    t = param.Timedelta(default=timedelta(seconds=30))
+    value = t("TIMEDELTA_NOT_DEFINED_SECONDS")
+    assert isinstance(value, timedelta)
+    assert value.total_seconds() == 30
+
+
+def test_timedelta_default_timedelta_2():
+    t = param.Timedelta(default=timedelta(seconds=30))
+    value = t("TIMEDELTA_NOT_DEFINED_HOURS")
+    assert isinstance(value, timedelta)
+    assert value.total_seconds() == 30


### PR DESCRIPTION
Bundling these two together because they are kind of related.

# Change: add `param.Datetime`

Adds `param.Datetime` for `datetime.datetime` params.

Maybe a little bit too magical but, the way I did this is to read from `*_FORMAT` envvar and pass it to `strptime`. So e.g. if you define `WINDOW_END = param.Datetime()`, we return `datetime.strptime(config.WINDOW_END, config.WINDOW_END_FORMAT)`.

The default format is ISO8601 format, seconds with no fractional component.

# Change: add `param.Timedelta`

Adds `param.Timedelta` for `datetime.timedelta` params.

Even more magical; using the last component of the envvar name to determine the units of the interval. So e.g. if you define `WINDOW_INTERVAL_DAYS = param.Timedelta()`, we return `datetime.timedelta(days=config.WINDOW_INTERVAL_DAYS)`.

It works for any of the `kwargs` of `datetime.timedelta`.