### PR TITLE
ensure default values have the same type as values retrieved from environment

### DIFF
--- a/envconfig/param.py
+++ b/envconfig/param.py
@@ -20,7 +20,13 @@ class Param(ABC):
     def __init__(self, override=None, default=None, required=False, prefix=None):
         self.override = override
         self.prefix = prefix
-        self.default = default
+
+        if default is not None:
+            # ensure the default value has the same type as the resolved values
+            self.default = self._cast(default)
+        else:
+            self.default = None
+
         self.required = required
 
     def __call__(self, name):


### PR DESCRIPTION
Mainly this is just to reduce the chance of a user getting tripped up on #8 if they specify a param like `WINDOW_END = param.Datetime(default="2022-05-02T23:51:23Z")` (if `WINDOW_END` envvar is not provided, `config.WINDOW_END` will be a `str` instead of a `datetime`).

But I could imagine similar classes of errors cropping up if the default value for a `param.Int` was a `float`, or vice-versa `param.Float` was an `int`.